### PR TITLE
Change "User Usage Conditions" to "Usage Conditions"

### DIFF
--- a/haikudepotserver-webapp/src/main/resources/webmessages_en.properties
+++ b/haikudepotserver-webapp/src/main/resources/webmessages_en.properties
@@ -130,10 +130,10 @@ authenticateUser.info.changePassword=The password was changed; you can now re-au
 authenticateUser.createUserAction.title=Register new user
 authenticateUser.initiatePasswordResetAction.title=Reset a forgotten password
 authenticateUser.agreeUserUsageConditions.message=Your account has authenticated, but before proceeding we need \
-  you to agree to the most recent user usage conditions.
+  you to agree to the most recent usage conditions.
 authenticateUser.agreeUserUsageConditionsAction.title=Agree
 authenticateUser.userUsageConditionsAge.statement=I am {0} years of age or older
-authenticateUser.userUsageConditionsDocument.statement=I agree to the usage conditions for users
+authenticateUser.userUsageConditionsDocument.statement=I agree to the usage conditions
 authenticateUser.userUsageConditionsDocument.read=read
 
 editPkgIcon.iconBitmap64File.required=The 64x64px version of the icon is required.
@@ -414,8 +414,8 @@ viewUser.lastAuthenticationTimestamp.undefined=Undefined
 viewUser.userUsageConditionsAgreement.title=Usage Conditions Agreement
 viewUser.userUsageConditionsAgreement.none=The user has not agreed to any usage conditions.
 viewUser.userUsageConditionsAgreement.timestampAgreed.title=Agreed At
-viewUser.userUsageConditionsAgreement.isLatest.true=User has agreed to the current wording of usage conditions for users.
-viewUser.userUsageConditionsAgreement.isLatest.false=User has agreed to older wording of usage conditions for users.
+viewUser.userUsageConditionsAgreement.isLatest.true=User has agreed to the current wording of usage conditions.
+viewUser.userUsageConditionsAgreement.isLatest.false=User has agreed to older wording of usage conditions.
 viewUser.userUsageConditionsAgreement.age.statement=User is {0} years of age or older.
 viewUser.userUsageConditionsAgreement.document.read=read
 


### PR DESCRIPTION
The HDS side of https://review.haiku-os.org/c/haiku/+/1869

This only touches the strings seen by the user at the HDS
website and the "user usage conditions" text itself.

Everywhere else (variable names, dev docs etc.) "user usage
conditions" is kept to stay explicit, in case usage conditions
for devs/translators/curators etc. are added in the future.