### PR TITLE
Sync'ing all webmessages_*.properties to the English version

### DIFF
--- a/haikudepotserver-webapp/src/main/resources/webmessages_de.properties
+++ b/haikudepotserver-webapp/src/main/resources/webmessages_de.properties
@@ -2,6 +2,8 @@
 # GERMAN LOCALIZATION
 # ---------------------
 
+# These are localization messages that appear in the application
+
 gen.home.title=Home
 gen.actions.title=Aktionen
 gen.code.title=Code
@@ -99,6 +101,9 @@ createUser.captchaResponse.required=Es wird eine Antwort auf die Frage im Bild b
 createUser.captchaResponse.badresponse=Entweder passt die Antwort nicht zur Frage im Bild, oder die Zeit zur Beantwortung ist abgelaufen. Es wurde ein neues Fragebild erzeugt.
 createUser.captchaResponse.title=Test auf ein menschliches Gegenüber
 createUser.action.title=Anlegen
+createUser.userUsageConditionsAge.statement=Ich bin {0} Jahre oder älter
+createUser.userUsageConditionsDocument.statement=Ich stimme den Nutzungsbedingungen zu
+createUser.userUsageConditionsDocument.read=lesen
 
 changePassword.oldPasswordClear.title=Aktuelles Kennwort
 changePassword.oldPasswordClear.required=Zur Bestätigung der Identität des Benutzers wird das aktuelle Kennwort benötigt.
@@ -127,12 +132,9 @@ authenticateUser.initiatePasswordResetAction.title=Vergessenes Kennwort zurücks
 authenticateUser.agreeUserUsageConditions.message=Sie sind bereits eingeloggt, müssen \
     allerdings noch den aktuellen Nutzungsbedingungen zustimmen.
 authenticateUser.agreeUserUsageConditionsAction.title=Zustimmmen
-authenticateUser.userUsageConditionsAge.statement=Ich bin {0} Jahre alt oder älter
+authenticateUser.userUsageConditionsAge.statement=Ich bin {0} Jahre oder älter
 authenticateUser.userUsageConditionsDocument.statement=Ich stimme den Nutzungsbedingungen zu
 authenticateUser.userUsageConditionsDocument.read=lesen
-
-editPkgProminence.prominence.title=Empfehlungsstufen
-editPkgProminence.action.title=Speichern
 
 editPkgIcon.iconBitmap64File.required=Es wird eine 64x64 Pixel große Version des Icons benötigt.
 editPkgIcon.iconBitmap64File.badsize=Die Datei ist zu groß oder zu klein, um als PNG Bild für dieses Icon benutzt zu werden.
@@ -150,7 +152,6 @@ editPkgIcon.iconHvifFile.required=Es wird eine HVIF Version des Icons benötigt.
 editPkgIcon.iconHvifFile.badformatorsize=Die Datei ist in keinem brauchbaren HVIF Format.
 editPkgIcon.iconHvifFile.title=Icon HVIF
 editPkgIcon.iconHvifFile.badsize=Die Datei ist zu groß für dieses Icon.
-editPkgIcon.iconHvifFile.clearAction.title=Leeren
 editPkgIcon.action.title=Icons speichern
 editPkgIcon.vectorOrBitmap.title=Format
 editPkgIcon.vectorOrBitmap.vector.title=Vektorgrafik
@@ -229,14 +230,16 @@ editPkgScreenshots.download.title=Herunterladen
 editPkgScreenshots.isSubordinate=Es wird gerade ein untergeordnetes Paket bearbeitet. Achtung: Wird das zugehörige \
   Haupt-Paket einmal bearbeitet, können die Screenshots des untergeordneten Pakets überschrieben werden.
 
-editPkgCategories.categories.title=Kategorien
-editPkgCategories.categories.maximumThreeNote=Es sind maximal drei Paket-Kategorien erlaubt.
-editPkgCategories.action.title=Speichern
-
-editUser.naturalLanguage.title=Sprache
-editUser.action.title=Änderungen speichern
-editUser.email.title=Email
-editUser.email.validEmail=Das Format der angegebenen Email-Adresse ist fehlerhaft.
+addEditUserRating.user.title=Benutzer
+addEditUserRating.naturalLanguage.title=Sprache
+addEditUserRating.comment.title=Kommentar
+addEditUserRating.comment.maxlength=Der Kommentar darf höchstens 4096 Zeichen lang sein.
+addEditUserRating.stability.title=Stabilität
+addEditUserRating.rating.title=Bewertung
+addEditUserRating.saveChangesAction.title=Änderungen speichern
+addEditUserRating.addAction.title=Hinzufügen
+addEditUserRating.userRatingStability.none=nicht bewerten
+addEditUserRating.empty=Ohne sinnvolle Daten kann keine Bewertung abgegeben werden.
 
 viewUserRating.active.title=Aktiv
 viewUserRating.user.title=Benutzer
@@ -253,17 +256,19 @@ viewUserRating.removeModal.description=Diese Aktion entfernt die Bewertung \
   vollständig aus dem Speicher. Sie kann nicht rückgängig gemacht werden.
 viewUserRating.removeModal.confirmAction.title=Entfernen
 viewUserRating.removeModal.cancelAction.title=Abbrechen
+rating.none=Noch ohne Bewertung
 
-addEditUserRating.user.title=Benutzer
-addEditUserRating.naturalLanguage.title=Sprache
-addEditUserRating.comment.title=Kommentar
-addEditUserRating.comment.maxlength=Der Kommentar darf höchstens 4096 Zeichen lang sein.
-addEditUserRating.stability.title=Stabilität
-addEditUserRating.rating.title=Bewertung
-addEditUserRating.saveChangesAction.title=Änderungen speichern
-addEditUserRating.addAction.title=Hinzufügen
-addEditUserRating.userRatingStability.none=nicht bewerten
-addEditUserRating.empty=Ohne sinnvolle Daten kann keine Bewertung abgegeben werden.
+editPkgProminence.prominence.title=Empfehlungsstufen
+editPkgProminence.action.title=Speichern
+
+editPkgCategories.categories.title=Kategorien
+editPkgCategories.categories.maximumThreeNote=Es sind maximal drei Paket-Kategorien erlaubt.
+editPkgCategories.action.title=Speichern
+
+editUser.naturalLanguage.title=Sprache
+editUser.action.title=Änderungen speichern
+editUser.email.title=Email
+editUser.email.validEmail=Das Format der angegebenen Email-Adresse ist fehlerhaft.
 
 listRepositories.search.go.title=Los
 listRepositories.noResults.title=Keine Treffer
@@ -273,6 +278,14 @@ listRepositories.table.label.title=Repository
 listRepositories.showInactiveAction.title=Zeige inaktive Repos
 listRepositories.addAction.title=Repo hinzufügen
 
+listUsers.search.go.title=Los
+listUsers.noResults.title=Kaine Treffer
+listUsers.noResults.description=Mit den verwendeten Suchkriterien wurden keine Benutzer gefunden.
+listUsers.table.active.title=Active
+listUsers.table.nickname.title=Benutzername
+listUsers.showInactiveAction.title=Zeige inaktive Benutzer
+listUsers.createUserAction.title=Benutzer anlegen
+
 listJobs.noResults.title=Keine Aufträge
 listJobs.noResults.description=Es wurden keine Aufträge gefunden.
 listJobs.table.id.title=Id
@@ -281,23 +294,6 @@ listJobs.table.user.title=Benutzer
 listJobs.table.queued.title=In Warteschlange
 listJobs.table.status.title=Status
 listJobs.refetchJobsAtFirstPageAction.title=Aktualisieren
-
-viewJob.typecode.title=Typ
-viewJob.queuedtimestamp.title=In Warteschlange
-viewJob.id.title=Id
-viewJob.status.title=Status
-viewJob.notfound.description=Der Auftrag ist nicht mehr verfügbar
-viewJob.refreshaction.title=Aktualisierung
-viewJob.generateddatas.title=Erzeugte Daten
-viewJob.generateddatas.table.filename.title=Dateiname
-
-listUsers.search.go.title=Los
-listUsers.noResults.title=Kaine Treffer
-listUsers.noResults.description=Mit den verwendeten Suchkriterien wurden keine Benutzer gefunden.
-listUsers.table.active.title=Active
-listUsers.table.nickname.title=Benutzername
-listUsers.showInactiveAction.title=Zeige inaktive Benutzer
-listUsers.createUserAction.title=Benutzer anlegen
 
 viewPkg.name.title=Name
 viewPkg.repository.title=Repository
@@ -339,13 +335,6 @@ viewPkg.viewPkgChangelogAction.title=Änderungsprotokoll
 viewPkg.deactivateAction.title=Deaktivieren
 viewPkg.active.title=Aktiv
 
-viewPkgChangelog.title=Änderungsprotokoll für '{0}'
-viewPkgChangelog.none=Für dieses Paket existiert kein Änderungsprotokoll.
-viewPkgChangelog.editAction.title=Bearbeiten
-
-editPkgChangelog.title=Änderungsprotokoll für '{0}'
-editPkgChangelog.action.title=Speichern
-
 viewRepository.importTriggered.title=Import angestoßen
 viewRepository.importTriggered.description=Die Anwendung wird in Kürze die Daten des Repositories importieren.
 viewRepository.name.title=Name
@@ -379,7 +368,6 @@ viewRepositorySource.lastImportTimestamp.missing=Noch nicht importiert
 viewRepositorySource.forcedInternalBaseUrl.title=Erzwungene Interne Base URL
 viewRepositorySource.forcedInternalBaseUrl.undefined=Undefiniert
 viewRepositorySource.repository.title=Repository
-viewRepositorySource.repoInfoUrl.undefined=Undefiniert
 viewRepositorySource.editAction.title=Bearbeiten
 viewRepositorySource.deactivateAction.title=Deaktivieren
 viewRepositorySource.reactivateAction.title=Reaktivieren
@@ -431,6 +419,41 @@ viewUser.userUsageConditionsAgreement.isLatest.false=Der Benutzer hat den alten 
 viewUser.userUsageConditionsAgreement.age.statement=Der Benutzer ist {0} Jahre alt oder älter alter.
 viewUser.userUsageConditionsAgreement.document.read=lesen
 
+viewJob.typecode.title=Typ
+viewJob.queuedtimestamp.title=In Warteschlange
+viewJob.id.title=Id
+viewJob.status.title=Status
+viewJob.notfound.description=Der Auftrag ist nicht mehr verfügbar
+viewJob.refreshaction.title=Aktualisierung
+viewJob.generateddatas.title=Erzeugte Daten
+viewJob.generateddatas.table.filename.title=Dateiname
+
+listPkgVersionsForPkg.title={0} Version für {1}
+listPkgVersionsForPkg.title.plural={0} Versionen für {1}
+listPkgVersionsForPkg.latest=Letzte
+listPkgVersionsForPkg.table.pkgVersion.title=Version
+listPkgVersionsForPkg.table.architecture.title=Architektur
+listPkgVersionsForPkg.table.repository.title=Repository
+
+viewPkgChangelog.title=Änderungsprotokoll für '{0}'
+viewPkgChangelog.none=Für dieses Paket existiert kein Änderungsprotokoll.
+viewPkgChangelog.editAction.title=Bearbeiten
+
+editPkgChangelog.title=Änderungsprotokoll für '{0}'
+editPkgChangelog.action.title=Speichern
+
+initiatePasswordReset.email.title=Email
+initiatePasswordReset.email.description=Die Email-Adresse des Benutzers dessen Kennwort zurückgesetzt werden soll.
+initiatePasswordReset.email.validEmail=Das Format der angegebenen Email-Adresse ist fehlerhaft.
+initiatePasswordReset.captchaResponse.required=Die Beantwortung der Frage im Bild dient als Test ob die Registrierung von einem Menschen beantragt wurde.
+initiatePasswordReset.captchaResponse.badresponse=Entweder die Antwort passt nicht zur Frage im Bild oder die Zeit zur Beantwortung ist bereits abgelaufen. Es wurde ein neues Fragebild erzeugt.
+initiatePasswordReset.captchaResponse.title=Mensch/Maschiene Prüfung
+initiatePasswordReset.action.title=Email senden
+initiatePasswordReset.done.title=Email gesendet
+initiatePasswordReset.done.description=Falls der Antrag durchgegangen ist, wurde eine Email an die hinterlegte \
+  Adresse geschickt. Sie enthält weitere Anweisungen zum Zurücksetzen des \
+  Kennworts dieses Kontos.
+
 completePasswordReset.oldPasswordClear.title=Existierendes Kennwort
 completePasswordReset.oldPasswordClear.required=Zur Bestätigung der Identität des Benutzers wird das aktuelle Kennwort benötigt.
 completePasswordReset.oldPasswordClear.mismatched=Fehler bei der Authentifizierung. Bitte nochmal das existierende Kennwort probieren.
@@ -449,25 +472,6 @@ completePasswordReset.done.description=Falls das Zurücksetzen des Kennworts erf
   mit dem angegebenen Kennwort neu konfiguriert.
 completePasswordReset.authenticateAction.title=Benutzer anmelden
 
-initiatePasswordReset.email.title=Email
-initiatePasswordReset.email.description=Die Email-Adresse des Benutzers dessen Kennwort zurückgesetzt werden soll.
-initiatePasswordReset.email.validEmail=Das Format der angegebenen Email-Adresse ist fehlerhaft.
-initiatePasswordReset.captchaResponse.required=Die Beantwortung der Frage im Bild dient als Test ob die Registrierung von einem Menschen beantragt wurde.
-initiatePasswordReset.captchaResponse.badresponse=Entweder die Antwort passt nicht zur Frage im Bild oder die Zeit zur Beantwortung ist bereits abgelaufen. Es wurde ein neues Fragebild erzeugt.
-initiatePasswordReset.captchaResponse.title=Mensch/Maschiene Prüfung
-initiatePasswordReset.action.title=Email senden
-initiatePasswordReset.done.title=Email gesendet
-initiatePasswordReset.done.description=Falls der Antrag durchgegangen ist, wurde eine Email an die hinterlegte \
-  Adresse geschickt. Sie enthält weitere Anweisungen zum Zurücksetzen des \
-  Kennworts dieses Kontos.
-
-listPkgVersionsForPkg.title={0} Version für {1}
-listPkgVersionsForPkg.title.plural={0} Versionen für {1}
-listPkgVersionsForPkg.latest=Letzte
-listPkgVersionsForPkg.table.pkgVersion.title=Version
-listPkgVersionsForPkg.table.architecture.title=Architektur
-listPkgVersionsForPkg.table.repository.title=Repository
-
 listAuthorizationPkgRules.searchAction.title=Los
 listAuthorizationPkgRules.addRuleAction.title=Regel hinzufügen
 listAuthorizationPkgRules.downloadCsvAction.title=Regeln als CSV unterladen
@@ -485,8 +489,7 @@ listAuthorizationPkgRules.pkgNameNotFound.description=Es wurde kein Paket mit de
 listAuthorizationPkgRules.deleteRuleModal.title=Regel löschen
 listAuthorizationPkgRules.deleteRuleModal.description=Soll diese Regel wirklich gelöscht werden?
 listAuthorizationPkgRules.deleteRuleModal.cancelAction.title=Abbruch
-listAuthorizationPkgRules.deleteRuleModal.confirmAction.title
-=Löschen
+listAuthorizationPkgRules.deleteRuleModal.confirmAction.title=Löschen
 listAuthorizationPkgRules.allPackages=Alle Pakete
 
 addAuthorizationPkgRule.userNickname.title=Benutzername
@@ -503,7 +506,24 @@ addAuthorizationPkgRule.pkgName.pattern=Der Paketname scheint nicht das korrekte
 addAuthorizationPkgRule.pkgName.notfound=Es wurde kein Paket mit dem angegebenen Namen gefunden.
 addAuthorizationPkgRule.action.title=Regel hinzufügen
 addAuthorizationPkgRule.conflict.title=Konflikt
-addAuthorizationPkgRule.conflict.description=Die Regel, die hinzugefügt werden soll, kollidiert mit einer bereits bestehenden Regel. Entweder besteht die exakt gleiche Regel bereits, oder vielleicht eine nur weniger spezifische.
+addAuthorizationPkgRule.conflict.description=Die Regel, die hinzugefügt werden soll, kollidiert mit \
+  einer bereits bestehenden Regel. Entweder besteht die exakt gleiche Regel bereits, oder vielleicht \
+  eine nur weniger spezifische.
+
+pkgCategoryCoverageImportSpreadsheet.importDataFile.title=Datei
+pkgCategoryCoverageImportSpreadsheet.importDataFile.required=Für den Import wird eine Datei benötigt.
+pkgCategoryCoverageImportSpreadsheet.action.title=Importieren
+
+pkgIconArchiveImport.importDataFile.required=Für den Import muss eine .tgz Datei hochgeladen werden.
+pkgIconArchiveImport.action.title=Import
+pkgIconArchiveImport.importDataFile.title=.tgz Datei
+
+pkgScreenshotArchiveImport.importStrategy.replace.title=Vorhandene Screenshots ersetzen
+pkgScreenshotArchiveImport.importStrategy.augment.title=Vorhandenen Screenshot behalten
+pkgScreenshotArchiveImport.importStrategy.title=Import Strategie
+pkgScreenshotArchiveImport.importDataFile.title=Datei
+pkgScreenshotArchiveImport.importDataFile.required=Für den Import wird eine Datei benötigt.
+pkgScreenshotArchiveImport.action.title=Importieren
 
 banner.action.more=Über Haiku Depot Server
 banner.action.authenticate=Benutzer anmelden
@@ -525,6 +545,7 @@ banner.actions.multipage.title=Einfache Darstellung
 banner.actions.documentation.title=Dokumentation
 banner.actions.ping.title=Überwachungs-Ping
 banner.actions.metric.title=Leistung / Statistik
+banner.actions.healthcheck.title=Zustandsprüfung
 banner.actionSection.infoAndContact.title=Info und Kontakt
 banner.actionSection.userAndPrivacy.title=Benutzer und Privacy
 banner.actionSection.navigation.title=Navigation
@@ -539,11 +560,10 @@ permission.pkg_editlocalization.title=Lokalisierung von Pakete bearbeiten
 permission.pkg_editprominence.title=Pakete Empfehlungsstufen bearbeiten
 permission.pkg_editchangelog.title=Paket-Änderungsprotokoll bearbeiten
 
-rating.none=Noch ohne Bewertung
-
 # These are used in the ATOM feed itself for the title of the feed
 feed.createdUserRating.atom.title={0} : Bewertung von {1}
 feed.createdPkgVersion.atom.title={0} : Neue Version
+feed.description=Dieser Feed zeigt Neuigkeiten zu Datenänderungen im HaikuDepotServer System.
 
 # These are used in the user-interface to describe the source of the feed items
 feed.source.createdpkgversion.title=Paketversion
@@ -564,25 +584,11 @@ pkgFeedBuilder.action.title=Feed-URL erzeugen
 pkgFeedBuilder.editAction.title=Feed-URL Eigenschaften bearbeiten
 pkgFeedBuilder.openFeedAction.title=Feed in neuem Fenster öffnen
 pkgFeedBuilder.info=Mit dieser Anwendung lassen sich ATOM-Feeds von Haiku Paket-Updates \
-  erzeugen. Einfach auswählen welche Infos empfangen werden sollen, dann \
-  die entsprechende URL erzeugen, die dann mit einer Feed-Sammel-Software \
-  genutzt werden kann.
+  erzeugen. Einfach auswählen welche Infos empfangen werden sollen, dann die entsprechende \
+  URL erzeugen, die dann mit einer Feed-Sammel-Software genutzt werden kann.
 
-pkgCategoryCoverageImportSpreadsheet.importDataFile.title=Datei
-pkgCategoryCoverageImportSpreadsheet.importDataFile.required=Für den Import wird eine Datei benötigt.
-pkgCategoryCoverageImportSpreadsheet.action.title=Importieren
-
-pkgIconArchiveImport.importDataFile.required=Für den Import muss eine .tgz Datei hochgeladen werden.
-pkgIconArchiveImport.action.title=Import
-pkgIconArchiveImport.importDataFile.title=.tgz Datei
-
-pkgScreenshotArchiveImport.importStrategy.replace.title=Vorhandene Screenshots ersetzen
-pkgScreenshotArchiveImport.importStrategy.augment.title=Vorhandenen Screenshot behalten
-pkgScreenshotArchiveImport.importStrategy.title=Import Strategie
-pkgScreenshotArchiveImport.importDataFile.title=Datei
-pkgScreenshotArchiveImport.importDataFile.required=Für den Import wird eine Datei benötigt.
-pkgScreenshotArchiveImport.action.title=Importieren
-
+reporting.didreject.description=Der Bericht konnte nicht in die Warteschlange aufgenommen werden; \
+  vielleicht läuft bereits ein ähnlicher Bericht.
 reporting.pkgcategorycoverageexportspreadsheet.title=Verteilung der Pakete nach Kategorien
 reporting.pkgcategorycoverageexportspreadsheet.description=Zeigt in welchen Kategorien die Pakete sind. \
   Umgekehrt kann man auch "*" in die entsprechende Kategoriespalte eintragen und das Ganze an den \
@@ -593,6 +599,10 @@ reporting.pkgprominenceanduserratingspreadsheetreport.description=Zeigt den "Pro
   Benutzerbewertungen aller Pakete.
 reporting.pkgiconspreadsheetreport.title=Icons der Pakete
 reporting.pkgiconspreadsheetreport.description=Zeigt für welche Pakete Icons hochgeladen wurden.
+reporting.pkgscreenshotexportarchive.title=Screenshots der Pakete als Archiv
+reporting.pkgscreenshotexportarchive.description=Erzeugt ein TAR Archiv aller hochgeladenen Screenshots.
+reporting.pkgscreenshotspreadsheetreport.title=Screenshots der Pakete
+reporting.pkgscreenshotspreadsheetreport.description=Zeigt für welche Pakete Screenshots hochgeladen wurden.
 reporting.userratingspreadsheetreportall.title=Alle Bewertungen
 reporting.pkgiconexportarchive.title=Icons der Pakete als Archiv
 reporting.pkgiconexportarchive.description=Erzeugt ein TAR Archiv aller hochgeladenen Icons.
@@ -601,15 +611,17 @@ reporting.pkgversionlocalizationcoverageexportspreadsheet.description=Zeigt welc
 reporting.pkglocalizationcoverageexportspreadsheet.title=Fallback Lokalisierungs-Abdeckung von Paketen
 reporting.pkglocalizationcoverageexportspreadsheet.description=Zeigt welche Pakete Übersetzungen haben und in welchen Sprachen. \
   Diese Übersetzungen werden normalerweise vom Benutzer bearbeitet.
-reporting.authorizationrulesspreadsheet.title=Autorisierungsregeln
-reporting.authorizationrulesspreadsheet.description=Eine Tabelle aller Autorisierungsregeln im System.
 reporting.table.report.title=Bericht
 reporting.table.description.title=Beschreibung
-reporting.didreject.description=Der Bericht konnte nicht in die Warteschlange aufgenommen werden; vielleicht läuft bereits ein ähnlicher Bericht.
-reporting.pkgscreenshotspreadsheetreport.title=Screenshots der Pakete
-reporting.pkgscreenshotspreadsheetreport.description=Zeigt für welche Pakete Screenshots hochgeladen wurden.
-reporting.pkgscreenshotexportarchive.title=Screenshots der Pakete als Archiv
-reporting.pkgscreenshotexportarchive.description=Erzeugt ein TAR Archiv aller hochgeladenen Screenshots.
+reporting.authorizationrulesspreadsheet.title=Autorisierungsregeln
+reporting.authorizationrulesspreadsheet.description=Eine Tabelle aller Autorisierungsregeln \
+  im System.
+
+# Multipage (non-AngularJS) Interface
+multipage.banner.title.suffix=Einfach
+multipage.banner.note=Dies ist die vereinfachte Darstellung, gedacht für Minimal-Browser
+multipage.banner.note.full=Standard-Darstellung
+multipage.home.allrepositories=Alle
 
 job.jobtype.pkgversionlocalizationcoverageexportspreadsheet.title=Lokalisierungs-Abdeckung von Paketversionen
 job.jobtype.passwordresetmaintenance.title=Kennwort zurücksetzen
@@ -622,20 +634,10 @@ job.jobtype.pkgscreenshotspreadsheet.title=Tabelle der Paket-Screenshots
 job.jobtype.userratingspreadsheet.title=Tabelle aller Bewertungen
 job.jobtype.pkgscreenshotoptimization.title=Screenshots optimieren
 job.jobtype.userratingderivation.title=Bewertungen berechnen
+job.jobtype.pkgscreenshotexportarchive.title=Paket-Screenshot exportieren
 
 job.jobstatus.finished.indicator=Fertig am {0}
 job.jobstatus.queued.indicator=In Warteschlage am {0}
 job.jobstatus.started.indicator=Begonnen am {0}
 job.jobstatus.failed.indicator=Fehlgeschlagen am {0}
 job.jobstatus.cancelled.indicator=Abgebrochen am {0}
-
-# Multipage (non-AngularJS) Interface
-multipage.banner.title.suffix=Einfach
-multipage.banner.note=Dies ist die vereinfachte Darstellung, gedacht für Minimal-Browser
-multipage.banner.note.full=Standard-Darstellung
-multipage.home.allrepositories=Alle
-
-# Test case
-
-test.it=Testzeile zum Test der Vollständigkeit
-

--- a/haikudepotserver-webapp/src/main/resources/webmessages_en.properties
+++ b/haikudepotserver-webapp/src/main/resources/webmessages_en.properties
@@ -102,7 +102,7 @@ createUser.captchaResponse.badresponse=The response supplied did not match the q
 createUser.captchaResponse.title=Check for a Person
 createUser.action.title=Create
 createUser.userUsageConditionsAge.statement=I am {0} years of age or older
-createUser.userUsageConditionsDocument.statement=I agree to the usage conditions for users
+createUser.userUsageConditionsDocument.statement=I agree to the usage conditions
 createUser.userUsageConditionsDocument.read=read
 
 changePassword.oldPasswordClear.title=Existing Password
@@ -130,10 +130,10 @@ authenticateUser.info.changePassword=The password was changed; you can now re-au
 authenticateUser.createUserAction.title=Register new user
 authenticateUser.initiatePasswordResetAction.title=Reset a forgotten password
 authenticateUser.agreeUserUsageConditions.message=Your account has authenticated, but before proceeding we need \
-  you to agree to the most recent user usage conditions.
+  you to agree to the most recent usage conditions.
 authenticateUser.agreeUserUsageConditionsAction.title=Agree
 authenticateUser.userUsageConditionsAge.statement=I am {0} years of age or older
-authenticateUser.userUsageConditionsDocument.statement=I agree to the usage conditions for users
+authenticateUser.userUsageConditionsDocument.statement=I agree to the usage conditions
 authenticateUser.userUsageConditionsDocument.read=read
 
 editPkgIcon.iconBitmap64File.required=The 64x64px version of the icon is required.
@@ -414,8 +414,8 @@ viewUser.lastAuthenticationTimestamp.undefined=Undefined
 viewUser.userUsageConditionsAgreement.title=Usage Conditions Agreement
 viewUser.userUsageConditionsAgreement.none=The user has not agreed to any usage conditions.
 viewUser.userUsageConditionsAgreement.timestampAgreed.title=Agreed At
-viewUser.userUsageConditionsAgreement.isLatest.true=User has agreed to the current wording of usage conditions for users.
-viewUser.userUsageConditionsAgreement.isLatest.false=User has agreed to older wording of usage conditions for users.
+viewUser.userUsageConditionsAgreement.isLatest.true=User has agreed to the current wording of usage conditions.
+viewUser.userUsageConditionsAgreement.isLatest.false=User has agreed to older wording of usage conditions.
 viewUser.userUsageConditionsAgreement.age.statement=User is {0} years of age or older.
 viewUser.userUsageConditionsAgreement.document.read=read
 

--- a/haikudepotserver-webapp/src/main/resources/webmessages_ja.properties
+++ b/haikudepotserver-webapp/src/main/resources/webmessages_ja.properties
@@ -20,6 +20,7 @@ gen.no=いいえ
 gen.ok=OK
 
 allowLocalStorage.message=アプリケーション設定とログイン情報をブラウザーに保存しますか?
+
 allowLocalStorage.question.allow=はい，ブラウザーに保存します
 allowLocalStorage.question.disallow=いいえ，ブラウザーに保存しません
 
@@ -156,6 +157,8 @@ editPkgIcon.vectorOrBitmap.title=フォーマット
 editPkgIcon.vectorOrBitmap.vector.title=ベクター
 editPkgIcon.vectorOrBitmap.bitmap.title=ビットマップ
 editPkgIcon.isSubordinate='下位パッケージ'を編集しています。アイコンは後で，この'下位パッケージ'に関連するメインパッケージの編集で上書きされるかもしれないことに注意してください。
+
+
 editPkgLocalization.anyPkgVersionLocalization.title=英文サンプル
 editPkgLocalization.anyPkgVersionLocalization.absent=表示するパッケージバージョンのローカライズがありません。
 editPkgLocalization.description.title=説明
@@ -165,6 +168,8 @@ editPkgLocalization.action.title=ローカライズの編集を保存
 editPkgLocalization.showAnyPkgVersionLocalizationAction.title=パッケージバージョンのローカライズを表示する。
 editPkgLocalization.englishNotLikelyToBeUsed=英語のパッケージ翻訳は使用されません。英語のローカライズは常にパッケージに含まれているからです。
 editPkgLocalization.devel=development-resourcesパッケージを編集しています。ローカライズは後で，この 'development-resourcesパッケージ' に関連するメインパッケージの編集で上書きされるかもしれないことに注意してください。
+
+
 
 viewPkgVersionLocalization.summary.title=要旨
 viewPkgVersionLocalization.description.title=説明
@@ -183,6 +188,7 @@ home.table.versionViewCounter.title=閲覧数
 home.table.rating.title=評価
 home.noResults.title=結果はありません
 home.noResults.description=検索基準からはパッケージは見つかりません。
+
 addEditRepository.code.required=コードが必要です
 addEditRepository.code.pattern=コードは2から16文字の英小文字と数字から構成される必要があります。
 addEditRepository.code.unique=このリポジトリに指定されたコードはすでに使用されています。別のコードを指定してください。
@@ -222,6 +228,8 @@ addPkgScreenshot.action.title=追加
 editPkgScreenshots.remove.title=削除
 editPkgScreenshots.download.title=ダウンロード
 editPkgScreenshots.isSubordinate='下位パッケージ'を編集しています。スクリーンショットは後で，この'下位パッケージ'に関連するメインパッケージの編集で上書きされるかもしれないことに注意してください。
+
+
 addEditUserRating.user.title=ユーザー
 addEditUserRating.naturalLanguage.title=使用言語
 addEditUserRating.comment.title=コメント
@@ -245,6 +253,7 @@ viewUserRating.removeAction.title=削除
 viewUserRating.editAction.title=編集
 viewUserRating.removeModal.title=ユーザー評価を削除
 viewUserRating.removeModal.description=この操作はユーザー評価データをストレージから恒久的に消去します。この操作は取り消しできません。
+
 viewUserRating.removeModal.confirmAction.title=削除
 viewUserRating.removeModal.cancelAction.title=キャンセル
 rating.none=評価が指定されていません
@@ -442,6 +451,9 @@ initiatePasswordReset.captchaResponse.title=ボットでないか確認
 initiatePasswordReset.action.title=Emailを送信
 initiatePasswordReset.done.title=Emailが送信されました
 initiatePasswordReset.done.description=リクエストが成功した場合，このアカウントのパスワードリセットに関する詳しい情報が記載されたメールを受け取るでしょう。
+
+
+
 completePasswordReset.oldPasswordClear.title=現在のパスワード
 completePasswordReset.oldPasswordClear.required=ユーザーの身元を証明するために，ユーザーの現在のパスワードが必要です。
 completePasswordReset.oldPasswordClear.mismatched=認証で問題が発生しました。現在のパスワードをもう一度入力してみてください。
@@ -457,6 +469,7 @@ completePasswordReset.captchaResponse.badresponse=回答がイメージ内の質
 completePasswordReset.captchaResponse.title=ボットでないか確認
 completePasswordReset.done.title=パスワードのリセット
 completePasswordReset.done.description=パスワードリセットに成功した場合，ユーザーのパスワードはすぐに指定したパスワードに再構築されます。
+
 completePasswordReset.authenticateAction.title=ユーザーログイン
 
 listAuthorizationPkgRules.searchAction.title=検索開始
@@ -571,7 +584,11 @@ pkgFeedBuilder.action.title=フィードURL作成
 pkgFeedBuilder.editAction.title=フィードURL設定を編集
 pkgFeedBuilder.openFeedAction.title=フィードを新しいウィンドウで開く
 pkgFeedBuilder.info=このアプリケーションは，Haikuパッケージからのアップデートで構成されるATOMフィードを生成できます。受信したいものを指定後,URLを生成してお気に入りのフィード集約ソフトで使用ください。
+
+
+
 reporting.didreject.description=リポートをキューに入れられません。すでに同等のリポートが実行されているためと思われます。
+
 reporting.pkgcategorycoverageexportspreadsheet.title=Package category coverage report
 reporting.pkgcategorycoverageexportspreadsheet.description=Shows what categories all packages are in. \
   This report goes both ways: you can edit report by putting "*" in the respective category \

--- a/haikudepotserver-webapp/src/main/resources/webmessages_pt.properties
+++ b/haikudepotserver-webapp/src/main/resources/webmessages_pt.properties
@@ -2,6 +2,7 @@
 # PORTUGUESE LOCALIZATION
 # ---------------------
 
+# These are localization messages that appear in the application
 
 gen.home.title=Início
 gen.actions.title=Ações
@@ -17,6 +18,13 @@ gen.help.title=Ajuda
 gen.yes=Sim
 gen.no=Não
 gen.ok=OK
+
+allowLocalStorage.message=Would you like application settings and login \
+    data to be stored in your browser?
+allowLocalStorage.question.allow=Yes store data in my browser
+allowLocalStorage.question.disallow=No do not store data in my browser
+
+userUsageConditions.link.title=Conditions of use / data-use information
 
 naturalLanguageChooser.legend.hasData=dados presentes
 naturalLanguageChooser.legend.hasLocalizationMessages=traduzido
@@ -93,6 +101,9 @@ createUser.captchaResponse.required=A resposta à questão da imagem é necessá
 createUser.captchaResponse.badresponse=A resposta fornecida não correspondia à questão da imagem ou a questão expirou. Foi disponibilizada uma nova imagem.
 createUser.captchaResponse.title=Verificar Pessoa
 createUser.action.title=Criar
+createUser.userUsageConditionsAge.statement=I am {0} years of age or older
+createUser.userUsageConditionsDocument.statement=I agree to the usage conditions
+createUser.userUsageConditionsDocument.read=read
 
 changePassword.oldPasswordClear.title=Palavra-passe Existente
 changePassword.oldPasswordClear.required=A palavra-passe existente deste utilizador é necessária para provar a identidade de um utilizador.
@@ -118,6 +129,12 @@ authenticateUser.info.createdAccount=A nova conta foi criada. Já pode iniciar s
 authenticateUser.info.changePassword=A palavra-passe foi alterada. Já pode efetuar novamente a autenticação com a nova palavra-passe.
 authenticateUser.createUserAction.title=Registar novo utilizador
 authenticateUser.initiatePasswordResetAction.title=Repor uma palavra-passe esquecida
+authenticateUser.agreeUserUsageConditions.message=Your account has authenticated, but before proceeding we need \
+  you to agree to the most recent user usage conditions.
+authenticateUser.agreeUserUsageConditionsAction.title=Agree
+authenticateUser.userUsageConditionsAge.statement=I am {0} years of age or older
+authenticateUser.userUsageConditionsDocument.statement=I agree to the usage conditions for users
+authenticateUser.userUsageConditionsDocument.read=read
 
 editPkgIcon.iconBitmap64File.required=A versão 64x64px do ícone é obrigatória.
 editPkgIcon.iconBitmap64File.badsize=O ficheiro é demasiado grande ou demasiado pequeno para ser uma imagem PNG adequada para este ícone.
@@ -175,6 +192,8 @@ home.noResults.description=Não foram encontrados pacotes para os critérios de 
 addEditRepository.code.required=O código é obrigatório
 addEditRepository.code.pattern=O código deve ser composto por 2 a 16 letras minúsculas e algarismos.
 addEditRepository.code.unique=O código indicado para este repositório já está em uso; indique um código diferente.
+addEditRepository.passwordClear.title=Password
+addEditRepository.passwordClear.required=Password is required
 addEditRepository.name.title=Nome
 addEditRepository.name.required=O nome é obrigatório
 addEditRepository.name.invalid=O nome não é válido
@@ -183,12 +202,12 @@ addEditRepository.informationUrl.malformed=O URL deve ser indicado corretamente
 addEditRepository.addAction.title=Adicionar
 addEditRepository.saveChangesAction.title=Guardar Alterações
 
-addEditRepositorySource.url.title=URL
+addEditRepositorySource.forcedInternalBaseUrl.title=Forced Internal Base URL
+addEditRepositorySource.forcedInternalBaseUrl.malformed=The URL must be well-formed
+addEditRepositorySource.forcedInternalBaseUrl.trailingslash=The URL should not have a trailing slash
 addEditRepositorySource.code.required=O código é obrigatório
 addEditRepositorySource.code.pattern=O código deve ser composto por 2 a 16 letras minúsculas e algarismos, um traço inferior (underscore) e depois um código de arquitetura.
 addEditRepositorySource.code.unique=O código indicado para esta origem de repositório já está em uso; indique um código diferente.
-addEditRepositorySource.url.required=O URL é obrigatório
-addEditRepositorySource.url.malformed=O URL deve ser indicado corretamente
 addEditRepositorySource.addAction.title=Adicionar
 addEditRepositorySource.saveChangesAction.title=Guardar Alterações
 
@@ -197,6 +216,9 @@ addEditRepositorySourceMirror.countryCode.title=País
 addEditRepositorySourceMirror.description.title=Descrição
 addEditRepositorySourceMirror.saveChangesAction.title=Guardar
 addEditRepositorySourceMirror.addAction.title=Adicionar
+addEditRepositorySourceMirror.baseUrl.malformed=The URL must be well-formed
+addEditRepositorySourceMirror.baseUrl.unique=The URL must be unique for a given repository source.
+addEditRepositorySourceMirror.baseUrl.required=The base URL is required
 
 addPkgScreenshot.file.badformatorsize=O ficheiro deve ser uma imagem PNG inferior a 1500x1500 e com menos de 2 megabytes.
 addPkgScreenshot.file.required=Para adicionar uma captura de ecrã é necessário um ficheiro de dados.
@@ -318,7 +340,9 @@ viewRepository.importTriggered.description=a aplicação irá importar em breve 
 viewRepository.name.title=Nome
 viewRepository.sources.title=Origens de Repositórios
 viewRepository.informationUrl.title=URL de Informação
+viewRepository.password.title=Has Password
 viewRepository.active.title=Ativo
+viewRepository.deletePasswordAction.title=Delete password
 viewRepository.addRepositorySourceAction.title=Adicionar origem
 viewRepository.deactivateAction.title=Desativar repositório e todas as origens
 viewRepository.reactivateAction.title=Reativar repositório
@@ -331,13 +355,20 @@ viewRepository.repositorySources.none.title=Sem Origens
 viewRepository.repositorySources.none.description=Não há origens a partir das quais obter pacotes para este repositório.
 viewRepository.repositorySources.table.active.title=Ativa
 viewRepository.repositorySources.table.code.title=Código
+viewRepository.repositorySources.table.lastImportTimestamp.title=Last Import
+viewRepository.repositorySources.lastImportTimestamp.missing=Not yet imported
 
 viewRepositorySource.importTriggered.title=Importação acionada
 viewRepositorySource.importTriggered.description=a aplicação irá importar em breve os dados da origem de repositório.
 viewRepositorySource.active.title=Ativa
 viewRepositorySource.url.title=URL (info.repo.)
 viewRepositorySource.url.undefined=Indefinido
+viewRepositorySource.lastImportTimestamp.title=Last Import
+viewRepositorySource.lastImportTimestamp.missing=Not yet imported
+viewRepositorySource.forcedInternalBaseUrl.title=Forced Internal Base URL
+viewRepositorySource.forcedInternalBaseUrl.undefined=Undefined
 viewRepositorySource.repository.title=Repositório
+viewRepositorySource.editAction.title=Edit
 viewRepositorySource.deactivateAction.title=Desativar
 viewRepositorySource.reactivateAction.title=Reativar
 viewRepositorySource.triggerImportAction.title=Acionar importação
@@ -361,6 +392,11 @@ viewRepositorySourceMirror.deactivateAction.title=Desativar
 viewRepositorySourceMirror.reactivateAction.title=Reativar
 viewRepositorySourceMirror.editAction.title=Editar
 viewRepositorySourceMirror.setPrimary.title=Definir como espelho (mirror) primário para a origem de repositório
+viewRepositorySourceMirror.removeAction.title=Remove
+viewRepositorySourceMirror.removeActionModal.title=Remove mirror
+viewRepositorySourceMirror.removeActionModal.description=Are you sure that you want to completely remove this mirror?
+viewRepositorySourceMirror.removeActionModal.cancelAction.title=Cancel
+viewRepositorySourceMirror.removeActionModal.confirmAction.title=Remove
 
 viewUser.active.title=Ativo
 viewUser.email.title=Correio eletrónico
@@ -372,6 +408,16 @@ viewUser.logoutAction.title=Terminar sessão
 viewUser.deactivateAction.title=Desativar
 viewUser.reactivateAction.title=Reativar
 viewUser.downloadUserRatingsAction.title=Descarregar avaliações de utilizador
+viewUser.lastAuthenticationTimestamp.title=Last Login
+viewUser.lastAuthenticationTimestamp.accuracyNote=(hour accuracte)
+viewUser.lastAuthenticationTimestamp.undefined=Undefined
+viewUser.userUsageConditionsAgreement.title=Usage Conditions Agreement
+viewUser.userUsageConditionsAgreement.none=The user has not agreed to any usage conditions.
+viewUser.userUsageConditionsAgreement.timestampAgreed.title=Agreed At
+viewUser.userUsageConditionsAgreement.isLatest.true=User has agreed to the current wording of usage conditions for users.
+viewUser.userUsageConditionsAgreement.isLatest.false=User has agreed to older wording of usage conditions for users.
+viewUser.userUsageConditionsAgreement.age.statement=User is {0} years of age or older.
+viewUser.userUsageConditionsAgreement.document.read=read
 
 viewJob.typecode.title=Tipo
 viewJob.queuedtimestamp.title=Em fila
@@ -484,6 +530,7 @@ banner.action.authenticate=Início de sessão
 banner.action.createUser=Registar novo utilizador
 banner.action.user=Ver detalhes de {0}
 banner.action.logout=Terminar sessão de {0}
+banner.action.disallowLocalStorage=Disallow browser storage
 banner.action.naturalLanguagePrefix=Língua:
 banner.action.repositories=Listar repositórios de pacotes
 banner.action.users=Listar utilizadores
@@ -499,6 +546,12 @@ banner.actions.documentation.title=Documentação
 banner.actions.ping.title=Monitorização de ping
 banner.actions.metric.title=Métricas / Estatísticas
 banner.actions.healthcheck.title=Verificação de saúde
+banner.actionSection.infoAndContact.title=Info and Contact
+banner.actionSection.userAndPrivacy.title=User and Privacy
+banner.actionSection.navigation.title=Navigation
+banner.actionSection.data.title=Data
+banner.actionSection.monitoringAndMetrics.title=Monitoring And Metrics
+banner.actionSection.root.title=Root
 
 permission.pkg_editicon.title=Editar ícone do Pacote
 permission.pkg_editscreenshot.title=Editar Capturas de Ecrã do Pacote
@@ -553,7 +606,6 @@ reporting.userratingspreadsheetreportall.title=Relatório de todas as avaliaçõ
 reporting.pkgiconexportarchive.title=Arquivo de ícones dos pacotes
 reporting.pkgiconexportarchive.description=Cria um arquivo "tar" todos os ícones armazenados de todos os pacotes.
 reporting.pkgversionlocalizationcoverageexportspreadsheet.title=Cobertura de localização incluída na versão do pacote.
-Package version bundled localization coverage
 reporting.pkgversionlocalizationcoverageexportspreadsheet.description=Mostra quais os pacotes que têm resumos/descrições \
   localizados para cada língua incluídos no ficheiro do pacote.
 reporting.pkglocalizationcoverageexportspreadsheet.title=Cobertura de localização de recurso dos pacotes

--- a/haikudepotserver-webapp/src/main/resources/webmessages_ru.properties
+++ b/haikudepotserver-webapp/src/main/resources/webmessages_ru.properties
@@ -19,6 +19,13 @@ gen.yes=Да
 gen.no=Нет
 gen.ok=OK
 
+allowLocalStorage.message=Would you like application settings and login \
+    data to be stored in your browser?
+allowLocalStorage.question.allow=Yes store data in my browser
+allowLocalStorage.question.disallow=No do not store data in my browser
+
+userUsageConditions.link.title=Conditions of use / data-use information
+
 naturalLanguageChooser.legend.hasData=данные доступны
 naturalLanguageChooser.legend.hasLocalizationMessages=переведено
 naturalLanguageChooser.showAllLanguages=Показать все языки
@@ -27,6 +34,7 @@ naturalLanguageChooser.showLanguagesInUse=Показать используем�
 breadcrumb.home.title=Главная
 breadcrumb.editRepository.title=Редактировать {0}
 breadcrumb.addRepository.title=Добавить репозиторий
+breadcrumb.addRepositorySourceMirror.title=Add Mirror
 breadcrumb.viewRepository.title={0}
 breadcrumb.listRepositories.title=Отобразить репозитории
 breadcrumb.runtimeInformation.title=Информация о рантайме
@@ -42,6 +50,7 @@ breadcrumb.editPkgIcon.title=Иконка
 breadcrumb.editPkgScreenshots.title=Скриншоты
 breadcrumb.editPkgLocalizations.title=Локализация
 breadcrumb.editUser.title=Редактировать
+breadcrumb.editRepositorySourceMirror.title=Edit Mirror
 breadcrumb.addUserRating.title=Добавить отзыв
 breadcrumb.editUserRating.title=Редактировать отзыв
 breadcrumb.viewUserRating.title=Посмотреть отзыв
@@ -61,9 +70,12 @@ breadcrumb.pkgCategoryCoverageImportSpreadsheet.title=Импортировать
 breadcrumb.viewPkgVersionLocalizations.title=Локализация
 breadcrumb.viewRepositorySource.title=Источник репозитория
 breadcrumb.editRepositorySource.title=Редактировать источник репозитория
+breadcrumb.viewRepositorySourceMirror.title=Repository Source Mirror
 breadcrumb.addRepositorySource.title=Добавить источник репозитория
 breadcrumb.viewPkgChangelog.title=Список изменений
 breadcrumb.editPkgChangelog.title=Редактировать список изменений
+breadcrumb.pkgIconArchiveImport.title=Import Icons
+breadcrumb.pkgScreenshotArchiveImport.title=Import Screenshots
 
 about.info.title=Информация
 about.info.version=Версия {0}
@@ -89,6 +101,9 @@ createUser.captchaResponse.required=Требуется ответ на вопр�
 createUser.captchaResponse.badresponse=Введенный ответ не соответствует вопросу из изображения, которое уже устарело. Воспользуйтесь новым изображением.
 createUser.captchaResponse.title=Проверка пользователя
 createUser.action.title=Создать
+createUser.userUsageConditionsAge.statement=I am {0} years of age or older
+createUser.userUsageConditionsDocument.statement=I agree to the usage conditions
+createUser.userUsageConditionsDocument.read=read
 
 changePassword.oldPasswordClear.title=Текущий пароль
 changePassword.oldPasswordClear.required=Требуется текущий пароль пользователя, дабы подтвердить идентификацию.
@@ -114,6 +129,12 @@ authenticateUser.info.createdAccount=Новый аккаунт был созда
 authenticateUser.info.changePassword=Пароль был изменен. Вы можете перезайти с использованием нового пароля.
 authenticateUser.createUserAction.title=Создать нового пользователя
 authenticateUser.initiatePasswordResetAction.title=Сбросить забытый пароль
+authenticateUser.agreeUserUsageConditions.message=Your account has authenticated, but before proceeding we need \
+  you to agree to the most recent user usage conditions.
+authenticateUser.agreeUserUsageConditionsAction.title=Agree
+authenticateUser.userUsageConditionsAge.statement=I am {0} years of age or older
+authenticateUser.userUsageConditionsDocument.statement=I agree to the usage conditions for users
+authenticateUser.userUsageConditionsDocument.read=read
 
 editPkgIcon.iconBitmap64File.required=Версия иконки с размерами 64x64px обязательна.
 editPkgIcon.iconBitmap64File.badsize=Файл слишком большой или маленький, чтобы быть подходящим PNG-изображением для этой иконки.
@@ -135,6 +156,8 @@ editPkgIcon.action.title=Сохранить иконки
 editPkgIcon.vectorOrBitmap.title=Формат
 editPkgIcon.vectorOrBitmap.vector.title=Векторный
 editPkgIcon.vectorOrBitmap.bitmap.title=Растровый
+editPkgIcon.isSubordinate=You are editing a 'subordinate package'.  Note that the icons may be later overridden by \
+  editing the main package relating to this 'subordinate package'.
 
 editPkgLocalization.anyPkgVersionLocalization.title=English sample
 editPkgLocalization.anyPkgVersionLocalization.absent=Локализированные версии пакета отсутствуют.
@@ -169,6 +192,8 @@ home.noResults.description=Ни один из пакетов не удовлет
 addEditRepository.code.required=Код обязателен.
 addEditRepository.code.pattern=Код должен содержать от 2 до 16 символов - букв нижнего регистра или цифр.
 addEditRepository.code.unique=Код, предложенный для данного репозитория, уже используется. Выберите другой вариант.
+addEditRepository.passwordClear.title=Password
+addEditRepository.passwordClear.required=Password is required
 addEditRepository.name.title=Название
 addEditRepository.name.required=Название обязательно для заполнения.
 addEditRepository.name.invalid=Название некорректно
@@ -186,6 +211,14 @@ addEditRepositorySource.url.malformed=Ссылка должна быть кор�
 addEditRepositorySource.addAction.title=Добавить
 addEditRepositorySource.saveChangesAction.title=Сохранить изменения
 
+addEditRepositorySourceMirror.baseUrl.title=Base URL
+addEditRepositorySourceMirror.countryCode.title=Country
+addEditRepositorySourceMirror.description.title=Description
+addEditRepositorySourceMirror.saveChangesAction.title=Save
+addEditRepositorySourceMirror.addAction.title=Add
+addEditRepositorySourceMirror.baseUrl.malformed=The URL must be well-formed
+addEditRepositorySourceMirror.baseUrl.unique=The URL must be unique for a given repository source.
+addEditRepositorySourceMirror.baseUrl.required=The base URL is required
 
 addPkgScreenshot.file.badformatorsize=Изображение должно иметь формат PNG, разрешение не более 1500x1500 и объем менее 2 Мб.
 addPkgScreenshot.file.required=Для добавления скриншота требуется наличие файла с изображением.
@@ -194,6 +227,8 @@ addPkgScreenshot.file.title=Изображение формата PNG
 addPkgScreenshot.action.title=Добавить
 editPkgScreenshots.remove.title=Удалить
 editPkgScreenshots.download.title=Скачать
+editPkgScreenshots.isSubordinate=You are editing a 'subordinate package'.  Note that the screenshots may be later overridden by \
+  editing the main package relating to this 'subordinate package'.
 
 addEditUserRating.user.title=Пользователь
 addEditUserRating.naturalLanguage.title=Язык
@@ -214,8 +249,13 @@ viewUserRating.rating.title=Оценка
 viewUserRating.stability.title=Стабильность
 viewUserRating.deactiveAction.title=Деактивировать
 viewUserRating.reactiveAction.title=Реактивировать
+viewUserRating.removeAction.title=Delete
 viewUserRating.editAction.title=Редактировать
-
+viewUserRating.removeModal.title=Delete User Rating
+viewUserRating.removeModal.description=This action will permanently remove the user \
+  rating data from storage.  This action is not able to be reversed.
+viewUserRating.removeModal.confirmAction.title=Delete
+viewUserRating.removeModal.cancelAction.title=Cancel
 rating.none=Отзыв не указан
 
 editPkgProminence.prominence.title=Популярность
@@ -292,13 +332,17 @@ viewPkg.userRating.user.by=от
 viewPkg.derivedUserRating.sampleSize={0} отзывов
 viewPkg.deriveAndStoreUserRatingAction.title=Пересчитать пользовательский рейтинг для этого пакета
 viewPkg.deriveAndStoreUserRatingAction.completed=– было затребовано
+viewPkg.deactivateAction.title=Deactivate
+viewPkg.active.title=Active
 
 viewRepository.importTriggered.title=Импорт инициирован
 viewRepository.importTriggered.description=приложение вскоре импортирует данные репозитория.
 viewRepository.name.title=Название
 viewRepository.sources.title=Источники репозитория
 viewRepository.informationUrl.title=Подробнее
+viewRepository.password.title=Has Password
 viewRepository.active.title=Активность
+viewRepository.deletePasswordAction.title=Delete password
 viewRepository.addRepositorySourceAction.title=Добавить источник
 viewRepository.deactivateAction.title=Деактивировать репозиторий и все источники
 viewRepository.reactivateAction.title=Реактивировать репозиторий
@@ -311,15 +355,48 @@ viewRepository.repositorySources.none.title=Источники отсутств�
 viewRepository.repositorySources.none.description=Источники, из которых можно получить пакеты для данного репозитория, отсутствуют.
 viewRepository.repositorySources.table.active.title=Активность
 viewRepository.repositorySources.table.code.title=Код
+viewRepository.repositorySources.table.lastImportTimestamp.title=Last Import
+viewRepository.repositorySources.lastImportTimestamp.missing=Not yet imported
 
 viewRepositorySource.importTriggered.title=Импорт запущен
 viewRepositorySource.importTriggered.description=Приложение вскоре импортирует данные репозитория.
 viewRepositorySource.active.title=Активность
 viewRepositorySource.url.title=Ссылка (repo.info)
+viewRepositorySource.url.undefined=Undefined
+viewRepositorySource.lastImportTimestamp.title=Last Import
+viewRepositorySource.lastImportTimestamp.missing=Not yet imported
+viewRepositorySource.forcedInternalBaseUrl.title=Forced Internal Base URL
+viewRepositorySource.forcedInternalBaseUrl.undefined=Undefined
 viewRepositorySource.repository.title=Репозиторий
+viewRepositorySource.editAction.title=Edit
 viewRepositorySource.deactivateAction.title=Деактивировать
 viewRepositorySource.reactivateAction.title=Реактивировать
 viewRepositorySource.triggerImportAction.title=Запустить импорт
+viewRepositorySource.addMirrorAction.title=Add Mirror
+viewRepositorySource.includeInactiveRepositorySourceMirrorsAction.title=Show any inactive mirrors
+viewRepositorySource.mirrors.title=Mirrors
+viewRepositorySource.repositorySourceMirrors.none.title=No Mirrors
+viewRepositorySource.repositorySourceMirrors.none.description=There are no mirrors configured for this repository source.
+viewRepositorySource.repositorySourceMirrors.table.isPrimary.title=Primary
+viewRepositorySource.repositorySourceMirrors.table.active.title=Active
+viewRepositorySource.repositorySourceMirrors.table.countryCode.title=Country
+viewRepositorySource.repositorySourceMirrors.table.baseUrl.title=Base URL
+viewRepositorySource.repositorySourceMirrors.detail.title=Detail...
+
+viewRepositorySourceMirror.active.title=Active
+viewRepositorySourceMirror.isPrimary.title=Primary
+viewRepositorySourceMirror.countryCode.title=Country
+viewRepositorySourceMirror.baseUrl.title=Base URL
+viewRepositorySourceMirror.description.title=Description
+viewRepositorySourceMirror.deactivateAction.title=Deactivate
+viewRepositorySourceMirror.reactivateAction.title=Reactivate
+viewRepositorySourceMirror.editAction.title=Edit
+viewRepositorySourceMirror.setPrimary.title=Set as primary mirror for repository source
+viewRepositorySourceMirror.removeAction.title=Remove
+viewRepositorySourceMirror.removeActionModal.title=Remove mirror
+viewRepositorySourceMirror.removeActionModal.description=Are you sure that you want to completely remove this mirror?
+viewRepositorySourceMirror.removeActionModal.cancelAction.title=Cancel
+viewRepositorySourceMirror.removeActionModal.confirmAction.title=Remove
 
 viewUser.active.title=Активность
 viewUser.email.title=Email
@@ -331,6 +408,16 @@ viewUser.logoutAction.title=Выйти
 viewUser.deactivateAction.title=Деактивировать
 viewUser.reactivateAction.title=Реактивировать
 viewUser.downloadUserRatingsAction.title=Скачать отзывы пользователей
+viewUser.lastAuthenticationTimestamp.title=Last Login
+viewUser.lastAuthenticationTimestamp.accuracyNote=(hour accuracte)
+viewUser.lastAuthenticationTimestamp.undefined=Undefined
+viewUser.userUsageConditionsAgreement.title=Usage Conditions Agreement
+viewUser.userUsageConditionsAgreement.none=The user has not agreed to any usage conditions.
+viewUser.userUsageConditionsAgreement.timestampAgreed.title=Agreed At
+viewUser.userUsageConditionsAgreement.isLatest.true=User has agreed to the current wording of usage conditions for users.
+viewUser.userUsageConditionsAgreement.isLatest.false=User has agreed to older wording of usage conditions for users.
+viewUser.userUsageConditionsAgreement.age.statement=User is {0} years of age or older.
+viewUser.userUsageConditionsAgreement.document.read=read
 
 viewJob.typecode.title=Тип
 viewJob.queuedtimestamp.title=В очереди
@@ -427,11 +514,23 @@ pkgCategoryCoverageImportSpreadsheet.importDataFile.title=Импортирова
 pkgCategoryCoverageImportSpreadsheet.importDataFile.required=Требуется указать источник для импорта данных.
 pkgCategoryCoverageImportSpreadsheet.action.title=Импорт
 
+pkgIconArchiveImport.importDataFile.title=.tgz file
+pkgIconArchiveImport.importDataFile.required=A .tgz file must be specified from your local disk for importing.
+pkgIconArchiveImport.action.title=Import
+
+pkgScreenshotArchiveImport.importStrategy.replace.title=Replace existing screenshots
+pkgScreenshotArchiveImport.importStrategy.augment.title=Add to existing screenshots
+pkgScreenshotArchiveImport.importStrategy.title=Import Strategy
+pkgScreenshotArchiveImport.importDataFile.title=Import Data
+pkgScreenshotArchiveImport.importDataFile.required=The import data is required to import from.
+pkgScreenshotArchiveImport.action.title=Import
+
 banner.action.more=О сервере 'Haiku Depot Server'
 banner.action.authenticate=Вход
 banner.action.createUser=Регистрация нового пользователя
 banner.action.user=Подробнее о {0}
 banner.action.logout=Выход {0}
+banner.action.disallowLocalStorage=Disallow browser storage
 banner.action.naturalLanguagePrefix=Язык:
 banner.action.repositories=Пакетные репозитории
 banner.action.users=Пользователи
@@ -444,6 +543,15 @@ banner.actions.runtimeInformation.title=Информация о рантайме
 banner.actions.haiku.title=Об операционной системе Haiku
 banner.actions.multipage.title=Упрощенная версия
 banner.actions.documentation.title=Документация
+banner.actions.ping.title=Monitoring ping
+banner.actions.metric.title=Metrics / statistics
+banner.actions.healthcheck.title=Health check
+banner.actionSection.infoAndContact.title=Info and Contact
+banner.actionSection.userAndPrivacy.title=User and Privacy
+banner.actionSection.navigation.title=Navigation
+banner.actionSection.data.title=Data
+banner.actionSection.monitoringAndMetrics.title=Monitoring And Metrics
+banner.actionSection.root.title=Root
 
 permission.pkg_editicon.title=Редактировать иконку пакета
 permission.pkg_editscreenshot.title=Редактировать скриншоты пакета
@@ -455,6 +563,7 @@ permission.pkg_editchangelog.title=Редактировать список из�
 # These are used in the ATOM feed itself for the title of the feed
 feed.createdUserRating.atom.title={0} : пользовательский отзыв из {1}
 feed.createdPkgVersion.atom.title={0} : новая версия
+feed.description=This feed provides updates on data changes in the HaikuDepotServer system. 
 
 # These are used in the user-interface to describe the source of the feed items
 feed.source.createdpkgversion.title=Версия пакета
@@ -489,6 +598,10 @@ reporting.pkgprominenceanduserratingspreadsheetreport.description=Показыв
   пакета в списке "Популярное"), а также собранные пользовательские отзывы для всех пакетов.
 reporting.pkgiconspreadsheetreport.title=Отчет об иконках пакетов
 reporting.pkgiconspreadsheetreport.description=Просмотр всех пакетов с иконками.
+reporting.pkgscreenshotexportarchive.title=Package screenshot archive
+reporting.pkgscreenshotexportarchive.description=Creates a tar-archive of all stored screenshots for all packages.
+reporting.pkgscreenshotspreadsheetreport.title=Package screenshot report
+reporting.pkgscreenshotspreadsheetreport.description=Show what packages have screenshots uploaded.
 reporting.userratingspreadsheetreportall.title=Отчет о всех отзывах пользователей
 reporting.pkgiconexportarchive.title=Архив иконок пакетов
 reporting.pkgiconexportarchive.description=Создает архив ZIP, содержащий все загруженные иконки.
@@ -500,7 +613,10 @@ reporting.pkglocalizationcoverageexportspreadsheet.description=Отобража�
   описания для каждого языка. Эти локализации обычно редактируются пользователями.
 reporting.table.report.title=Отчет
 reporting.table.description.title=Описание
-
+reporting.authorizationrulesspreadsheet.title=Authorization rules
+reporting.authorizationrulesspreadsheet.description=A spreadsheet dump of each of the authorization rules in the \
+  system.
+  
 # Multipage (non-AngularJS) Interface
 multipage.banner.title.suffix=Простой
 multipage.banner.note=Вы пользуетесь упрощенным интерфейсом для браузеров, имеющих ограниченные возможности
@@ -514,8 +630,11 @@ job.jobtype.pkgprominenceanduserratingspreadsheet.title=Таблица "попу
 job.jobtype.pkgcategorycoverageexportspreadsheet.title=Таблица категорий пакетов
 job.jobtype.pkgcategorycoverageimportspreadsheet.title=Импорт таблицы категорий пакетов
 job.jobtype.pkgiconspreadsheet.title=Таблица иконок пакетов
+job.jobtype.pkgscreenshotspreadsheet.title=Package Screenshot Spreadsheet
 job.jobtype.userratingspreadsheet.title=Таблица пользовательских отзывов
 job.jobtype.pkgscreenshotoptimization.title=Оптимизация скриншотов пакетов
+job.jobtype.userratingderivation.title=User Rating Derivation
+job.jobtype.pkgscreenshotexportarchive.title=Package Screenshot Export
 
 job.jobstatus.finished.indicator=Завершено в {0}
 job.jobstatus.queued.indicator=Поставлено в очередь в {0}

--- a/haikudepotserver-webapp/src/main/resources/webmessages_sk.properties
+++ b/haikudepotserver-webapp/src/main/resources/webmessages_sk.properties
@@ -1,5 +1,5 @@
 # ---------------------
-# ENGLISH (AND FALLBACK) LOCALIZATION
+# SLOVAKIAN LOCALIZATION
 # ---------------------
 
 # These are localization messages that appear in the application
@@ -19,6 +19,13 @@ gen.yes=Áno
 gen.no=Nie
 gen.ok=OK
 
+allowLocalStorage.message=Would you like application settings and login \
+    data to be stored in your browser?
+allowLocalStorage.question.allow=Yes store data in my browser
+allowLocalStorage.question.disallow=No do not store data in my browser
+
+userUsageConditions.link.title=Conditions of use / data-use information
+
 naturalLanguageChooser.legend.hasData=prítomné dáta
 naturalLanguageChooser.legend.hasLocalizationMessages=preložené
 naturalLanguageChooser.showAllLanguages=Zobraziť všetky jazyky
@@ -27,6 +34,7 @@ naturalLanguageChooser.showLanguagesInUse=Zobraziť používané jazyky
 breadcrumb.home.title=Domov
 breadcrumb.editRepository.title=Upraviť {0}
 breadcrumb.addRepository.title=Pridať zdroj softvéru
+breadcrumb.addRepositorySourceMirror.title=Add Mirror
 breadcrumb.viewRepository.title={0}
 breadcrumb.listRepositories.title=Zoznam zdrojov softvéru
 breadcrumb.runtimeInformation.title=Dynamické informácie
@@ -42,6 +50,7 @@ breadcrumb.editPkgIcon.title=Ikona
 breadcrumb.editPkgScreenshots.title=Snímky obrazovky
 breadcrumb.editPkgLocalizations.title=Záložná lokalizácia
 breadcrumb.editUser.title=Upraviť
+breadcrumb.editRepositorySourceMirror.title=Edit Mirror
 breadcrumb.addUserRating.title=Pridať používateľské hodnotenie
 breadcrumb.editUserRating.title=Upraviť používateľské hodnotenie
 breadcrumb.viewUserRating.title=Zobraziť používateľské hodnotenie
@@ -61,10 +70,12 @@ breadcrumb.pkgCategoryCoverageImportSpreadsheet.title=Importovať kategórie bal
 breadcrumb.viewPkgVersionLocalizations.title=Lokalizácie
 breadcrumb.viewRepositorySource.title=Zdroj zdroja softvéru
 breadcrumb.editRepositorySource.title=Upraviť zdroj zdroja softvéru
+breadcrumb.viewRepositorySourceMirror.title=Repository Source Mirror
 breadcrumb.addRepositorySource.title=Pridať zdroj zdroja softvéru
 breadcrumb.viewPkgChangelog.title=Záznam zmien
 breadcrumb.editPkgChangelog.title=Upraviť záznam zmien
 breadcrumb.pkgIconArchiveImport.title=Importovať archív ikon
+breadcrumb.pkgScreenshotArchiveImport.title=Import Screenshots
 
 about.info.title=Informácie
 about.info.version=Verzia {0}
@@ -90,6 +101,9 @@ createUser.captchaResponse.required=Odpoveď na otázku na obrázku je potrebná
 createUser.captchaResponse.badresponse=Zadaná odpoveď nezodpovedá otázke na obrázku alebo platnosť otázky vypršala. Bol vytvorený nový obrázok.
 createUser.captchaResponse.title=Skontrolovať osobu
 createUser.action.title=Vytvoriť
+createUser.userUsageConditionsAge.statement=I am {0} years of age or older
+createUser.userUsageConditionsDocument.statement=I agree to the usage conditions
+createUser.userUsageConditionsDocument.read=read
 
 changePassword.oldPasswordClear.title=Existujúce heslo
 changePassword.oldPasswordClear.required=Je potrebné zadať existujúce heslo tohto používateľa na preukázanie identity používateľa.
@@ -115,6 +129,12 @@ authenticateUser.info.createdAccount=Nový účet bol vytvorený. Teraz sa môž
 authenticateUser.info.changePassword=Heslo bolo zmenené. Teraz sa môžete znova prihlásiť s novým heslom.
 authenticateUser.createUserAction.title=Zaregistrovať nového používateľa
 authenticateUser.initiatePasswordResetAction.title=Obnoviť zabudnuté heslo
+authenticateUser.agreeUserUsageConditions.message=Your account has authenticated, but before proceeding we need \
+  you to agree to the most recent user usage conditions.
+authenticateUser.agreeUserUsageConditionsAction.title=Agree
+authenticateUser.userUsageConditionsAge.statement=I am {0} years of age or older
+authenticateUser.userUsageConditionsDocument.statement=I agree to the usage conditions for users
+authenticateUser.userUsageConditionsDocument.read=read
 
 editPkgIcon.iconBitmap64File.required=Je potrebná verzia ikony v rozlíšení 64x64 px.
 editPkgIcon.iconBitmap64File.badsize=Súbor je príliš veľký alebo príliš malý, aby to bol obrázok PNG vhodný pre túto ikonu.
@@ -136,6 +156,8 @@ editPkgIcon.action.title=Uložiť ikony
 editPkgIcon.vectorOrBitmap.title=Formát
 editPkgIcon.vectorOrBitmap.vector.title=Vektorová
 editPkgIcon.vectorOrBitmap.bitmap.title=Rastrová
+editPkgIcon.isSubordinate=You are editing a 'subordinate package'.  Note that the icons may be later overridden by \
+  editing the main package relating to this 'subordinate package'.
 
 editPkgLocalization.anyPkgVersionLocalization.title=Anglická vzorka
 editPkgLocalization.anyPkgVersionLocalization.absent=Neexistuje lokalizácia verzie balíka, ktorú by bolo možné zobraziť.
@@ -170,6 +192,8 @@ home.noResults.description=Podľa vašich vyhľadávacích kritérií sme nenaš
 addEditRepository.code.required=Kód je povinný
 addEditRepository.code.pattern=Kód musí mať dĺžku 2 až 16 malých písmen a číslic.
 addEditRepository.code.unique=Kód zadaný pre tento zdroj softvéru sa už používa. Zadajte iný kód.
+addEditRepository.passwordClear.title=Password
+addEditRepository.passwordClear.required=Password is required
 addEditRepository.name.title=Názov
 addEditRepository.name.required=Názov je povinný
 addEditRepository.name.invalid=Názov je neplatný
@@ -178,15 +202,23 @@ addEditRepository.informationUrl.malformed=URL musí mať správny tvar
 addEditRepository.addAction.title=Pridať
 addEditRepository.saveChangesAction.title=Uložiť zmeny
 
-addEditRepositorySource.url.title=URL
+addEditRepositorySource.forcedInternalBaseUrl.title=Forced Internal Base URL
+addEditRepositorySource.forcedInternalBaseUrl.malformed=The URL must be well-formed
+addEditRepositorySource.forcedInternalBaseUrl.trailingslash=The URL should not have a trailing slash
 addEditRepositorySource.code.required=Kód je povinný
 addEditRepositorySource.code.pattern=Kód musí mať dĺžku 2 až 16 malých písmen a číslic, podtržítko a kód architektúry.
 addEditRepositorySource.code.unique=Kód zadaný pre tento zdroj softvéru sa už používa. Zadajte iný kód.
-addEditRepositorySource.url.required=URL je povinný
-addEditRepositorySource.url.malformed=URL musí mať správny tvar
 addEditRepositorySource.addAction.title=Pridať
 addEditRepositorySource.saveChangesAction.title=Uložiť zmeny
 
+addEditRepositorySourceMirror.baseUrl.title=Base URL
+addEditRepositorySourceMirror.countryCode.title=Country
+addEditRepositorySourceMirror.description.title=Description
+addEditRepositorySourceMirror.saveChangesAction.title=Save
+addEditRepositorySourceMirror.addAction.title=Add
+addEditRepositorySourceMirror.baseUrl.malformed=The URL must be well-formed
+addEditRepositorySourceMirror.baseUrl.unique=The URL must be unique for a given repository source.
+addEditRepositorySourceMirror.baseUrl.required=The base URL is required
 
 addPkgScreenshot.file.badformatorsize=Súbor musí byť obrázok PNG, ktorý nie je väčší ako 1500x1500 pixelov ani menší ako 2 megabajty.
 addPkgScreenshot.file.required=Pridanie snímky obrazovky vyžaduje dátový súbor.
@@ -195,6 +227,8 @@ addPkgScreenshot.file.title=Súbor s obrázkom PNG
 addPkgScreenshot.action.title=Pridať
 editPkgScreenshots.remove.title=Odstrániť
 editPkgScreenshots.download.title=Stiahnuť
+editPkgScreenshots.isSubordinate=You are editing a 'subordinate package'.  Note that the screenshots may be later overridden by \
+  editing the main package relating to this 'subordinate package'.
 
 addEditUserRating.user.title=Používateľ
 addEditUserRating.naturalLanguage.title=Jazyk
@@ -215,8 +249,13 @@ viewUserRating.rating.title=Hodnotenie
 viewUserRating.stability.title=Stabilita
 viewUserRating.deactiveAction.title=Deaktivovať
 viewUserRating.reactiveAction.title=Reaktivovať
+viewUserRating.removeAction.title=Delete
 viewUserRating.editAction.title=Upraviť
-
+viewUserRating.removeModal.title=Delete User Rating
+viewUserRating.removeModal.description=This action will permanently remove the user \
+  rating data from storage.  This action is not able to be reversed.
+viewUserRating.removeModal.confirmAction.title=Delete
+viewUserRating.removeModal.cancelAction.title=Cancel
 rating.none=Nebolo zadané hodnotenie
 
 editPkgProminence.prominence.title=Význam
@@ -301,7 +340,9 @@ viewRepository.importTriggered.description=aplikácia čoskoro naimportuje údaj
 viewRepository.name.title=Názov
 viewRepository.sources.title=Zdroje zdroja softvéru
 viewRepository.informationUrl.title=Informačný URL
+viewRepository.password.title=Has Password
 viewRepository.active.title=Aktívny
+viewRepository.deletePasswordAction.title=Delete password
 viewRepository.addRepositorySourceAction.title=Pridať zdroj
 viewRepository.deactivateAction.title=Deaktivovať zdroj softvéru a všetky zdroje
 viewRepository.reactivateAction.title=Reaktivovať zdroj softvéru
@@ -314,15 +355,48 @@ viewRepository.repositorySources.none.title=Žiadne zdroje
 viewRepository.repositorySources.none.description=Neexistujú žiadne zdroje, z ktorých by ste mohli získať balíky pre tento zdroj softvéru.
 viewRepository.repositorySources.table.active.title=Aktívny
 viewRepository.repositorySources.table.code.title=Kód
+viewRepository.repositorySources.table.lastImportTimestamp.title=Last Import
+viewRepository.repositorySources.lastImportTimestamp.missing=Not yet imported
 
 viewRepositorySource.importTriggered.title=Import spustený
 viewRepositorySource.importTriggered.description=aplikácia čoskoro naimportuje údaje zdroja zdroja softvéru.
 viewRepositorySource.active.title=Aktívny
 viewRepositorySource.url.title=URL (repo.info)
+viewRepositorySource.url.undefined=Undefined
+viewRepositorySource.lastImportTimestamp.title=Last Import
+viewRepositorySource.lastImportTimestamp.missing=Not yet imported
+viewRepositorySource.forcedInternalBaseUrl.title=Forced Internal Base URL
+viewRepositorySource.forcedInternalBaseUrl.undefined=Undefined
 viewRepositorySource.repository.title=Zdroj softvéru
+viewRepositorySource.editAction.title=Edit
 viewRepositorySource.deactivateAction.title=Deaktivovať
 viewRepositorySource.reactivateAction.title=Reaktivovať
 viewRepositorySource.triggerImportAction.title=Spustiť import
+viewRepositorySource.addMirrorAction.title=Add Mirror
+viewRepositorySource.includeInactiveRepositorySourceMirrorsAction.title=Show any inactive mirrors
+viewRepositorySource.mirrors.title=Mirrors
+viewRepositorySource.repositorySourceMirrors.none.title=No Mirrors
+viewRepositorySource.repositorySourceMirrors.none.description=There are no mirrors configured for this repository source.
+viewRepositorySource.repositorySourceMirrors.table.isPrimary.title=Primary
+viewRepositorySource.repositorySourceMirrors.table.active.title=Active
+viewRepositorySource.repositorySourceMirrors.table.countryCode.title=Country
+viewRepositorySource.repositorySourceMirrors.table.baseUrl.title=Base URL
+viewRepositorySource.repositorySourceMirrors.detail.title=Detail...
+
+viewRepositorySourceMirror.active.title=Active
+viewRepositorySourceMirror.isPrimary.title=Primary
+viewRepositorySourceMirror.countryCode.title=Country
+viewRepositorySourceMirror.baseUrl.title=Base URL
+viewRepositorySourceMirror.description.title=Description
+viewRepositorySourceMirror.deactivateAction.title=Deactivate
+viewRepositorySourceMirror.reactivateAction.title=Reactivate
+viewRepositorySourceMirror.editAction.title=Edit
+viewRepositorySourceMirror.setPrimary.title=Set as primary mirror for repository source
+viewRepositorySourceMirror.removeAction.title=Remove
+viewRepositorySourceMirror.removeActionModal.title=Remove mirror
+viewRepositorySourceMirror.removeActionModal.description=Are you sure that you want to completely remove this mirror?
+viewRepositorySourceMirror.removeActionModal.cancelAction.title=Cancel
+viewRepositorySourceMirror.removeActionModal.confirmAction.title=Remove
 
 viewUser.active.title=Aktívny
 viewUser.email.title=Email
@@ -334,6 +408,16 @@ viewUser.logoutAction.title=Odhlásiť sa
 viewUser.deactivateAction.title=Deaktivovať
 viewUser.reactivateAction.title=Reaktivovať
 viewUser.downloadUserRatingsAction.title=Stiahnuť používateľské hodnotenia
+viewUser.lastAuthenticationTimestamp.title=Last Login
+viewUser.lastAuthenticationTimestamp.accuracyNote=(hour accuracte)
+viewUser.lastAuthenticationTimestamp.undefined=Undefined
+viewUser.userUsageConditionsAgreement.title=Usage Conditions Agreement
+viewUser.userUsageConditionsAgreement.none=The user has not agreed to any usage conditions.
+viewUser.userUsageConditionsAgreement.timestampAgreed.title=Agreed At
+viewUser.userUsageConditionsAgreement.isLatest.true=User has agreed to the current wording of usage conditions for users.
+viewUser.userUsageConditionsAgreement.isLatest.false=User has agreed to older wording of usage conditions for users.
+viewUser.userUsageConditionsAgreement.age.statement=User is {0} years of age or older.
+viewUser.userUsageConditionsAgreement.document.read=read
 
 viewJob.typecode.title=Typ
 viewJob.queuedtimestamp.title=Vo fronte
@@ -425,6 +509,7 @@ addAuthorizationPkgRule.conflict.title=Konflikt
 addAuthorizationPkgRule.conflict.description=Pravidlo, ktoré ste sa pokúsili pridať je v konflikte s už existujúcim pravidlom. \
   Je možné, že už existuje rovnaké pravidlo alebo už existuje špecifickejšie pravidlo.
 
+
 pkgCategoryCoverageImportSpreadsheet.importDataFile.title=Importovať dáta
 pkgCategoryCoverageImportSpreadsheet.importDataFile.required=Na importovanie dáta sú potrebné dáta na import.
 pkgCategoryCoverageImportSpreadsheet.action.title=Importovať
@@ -433,11 +518,19 @@ pkgIconArchiveImport.importDataFile.title=súbor .tgz
 pkgIconArchiveImport.importDataFile.required=Na importovanie musíte vybrať súbor .tgz z vášho lokálneho disku.
 pkgIconArchiveImport.action.title=Importovať
 
+pkgScreenshotArchiveImport.importStrategy.replace.title=Replace existing screenshots
+pkgScreenshotArchiveImport.importStrategy.augment.title=Add to existing screenshots
+pkgScreenshotArchiveImport.importStrategy.title=Import Strategy
+pkgScreenshotArchiveImport.importDataFile.title=Import Data
+pkgScreenshotArchiveImport.importDataFile.required=The import data is required to import from.
+pkgScreenshotArchiveImport.action.title=Import
+
 banner.action.more=O „Haiku Depot Server“
 banner.action.authenticate=Prihlásiť sa
 banner.action.createUser=Zaregistrovať nového používateľa
 banner.action.user=Zobraziť podrobnosti o {0}
 banner.action.logout=Odhlásiť {0}
+banner.action.disallowLocalStorage=Disallow browser storage
 banner.action.naturalLanguagePrefix=Jazyk:
 banner.action.repositories=Zoznam zdrojov softvéru
 banner.action.users=Zoznam používateľov
@@ -452,6 +545,13 @@ banner.actions.multipage.title=Zjednodušená verzia
 banner.actions.documentation.title=Dokumentácia
 banner.actions.ping.title=Monitorovací ping
 banner.actions.metric.title=Metriky / štatistiky
+banner.actions.healthcheck.title=Health check
+banner.actionSection.infoAndContact.title=Info and Contact
+banner.actionSection.userAndPrivacy.title=User and Privacy
+banner.actionSection.navigation.title=Navigation
+banner.actionSection.data.title=Data
+banner.actionSection.monitoringAndMetrics.title=Monitoring And Metrics
+banner.actionSection.root.title=Root
 
 permission.pkg_editicon.title=Upraviť ikonu balíka
 permission.pkg_editscreenshot.title=Upraviť snímky obrazovky balíka
@@ -467,6 +567,7 @@ feed.createdPkgVersion.atom.title={0} : nová verzia
 # These are used in the user-interface to describe the source of the feed items
 feed.source.createdpkgversion.title=Verzia balíka
 feed.source.createduserrating.title=Používateľské hodnotenie
+feed.description=This feed provides updates on data changes in the HaikuDepotServer system.
 
 # These are used in the page where the user is able to specify what they want in
 # the feed.
@@ -515,6 +616,7 @@ reporting.table.description.title=Popis
 reporting.authorizationrulesspreadsheet.title=Autorizačné pravidlá
 reporting.authorizationrulesspreadsheet.description=Výpis všetkých autorizačných pravidiel v systéme vo forme hárka.
 
+
 # Multipage (non-AngularJS) Interface
 multipage.banner.title.suffix=Zjednodušené
 multipage.banner.note=Používate zjednodušené používateľské rozhranie pre staršie prehliadače
@@ -532,6 +634,7 @@ job.jobtype.pkgscreenshotspreadsheet.title=Hárok snímok obrazovky balíkov
 job.jobtype.userratingspreadsheet.title=Hárok používateľských hodnotení balíkov
 job.jobtype.pkgscreenshotoptimization.title=Optimalizácia snímok obrazovky balíkov
 job.jobtype.userratingderivation.title=Odvodenie používateľských hodnotení
+job.jobtype.pkgscreenshotexportarchive.title=Package Screenshot Export
 
 job.jobstatus.finished.indicator=Dokončené {0}
 job.jobstatus.queued.indicator=Vo fronte {0}


### PR DESCRIPTION
Having all lines in the the exact same order makes it easier
to compare the state of the translations. Missing variables
are quickly spotted by diverging line numbers.

New variables should be added to all files at the same position.