### PR TITLE
Defined more architectures

### DIFF
--- a/haikudepotserver-core/src/main/java/org/haiku/haikudepotserver/dataobjects/Architecture.java
+++ b/haikudepotserver-core/src/main/java/org/haiku/haikudepotserver/dataobjects/Architecture.java
@@ -26,6 +26,12 @@ public class Architecture extends _Architecture {
     public final static String CODE_SOURCE = "source";
     public final static String CODE_ANY = "any";
     public final static String CODE_X86_64 = "x86_64";
+    public final static String CODE_PPC = "PowerPC";
+    public final static String CODE_ARM = "ARM";
+    public final static String CODE_M68K = "M68K";
+    public final static String CODE_SPARC = "SPARC";
+    public final static String CODE_ARM64 = "ARM64";
+    public final static String CODE_RISCV64 = "RISC-V";
 
     public static List<Architecture> getAll(ObjectContext context) {
         Preconditions.checkArgument(null != context, "the context must be provided");


### PR DESCRIPTION
- See https://github.com/haiku/haikudepotserver/blob/master/haikudepotserver-packagefile/src/main/java/org/haiku/pkg/model/PkgArchitecture.java

---

I tried to check the web application to see a list of applications that run on non-`x86`/`x86_64` architectures and saw that these architectures were not listed, so I tried implementing that myself. From my understanding, architectures are initialized with a code and are then listed on the website thanks to a function that obtains all of the architectures that were initialized in `haikudepotserver-core`. I called the commit "Defined more architectures" for now because I am frankly not sure whether I achieved what I wanted to achieve.

From my understanding, which is likely to be inaccurate, `haikudepotserver-core-test` is a slightly torn down version of `haikudepotserver-core` with some example metadata for testing purposes. I noticed that there was some code that was implemented for voting for packages, which included references to the `x86_64` architecture. I wasn't sure whether I forgot to implement something, or whether that's negligible. I also was not sure what [this was supposed to be or whether I should have touched it at all](https://github.com/haiku/haikudepotserver/blob/02ab8fa7df47037dacd4fbe6568bda73f2f41389/haikudepotserver-core-test/src/test/java/org/haiku/haikudepotserver/userrating/UserRatingOrchestrationServiceIT.java).