### PR TITLE
opensearchdescription-body.ftl: update to naturalLanguageCoordinates

### DIFF
--- a/haikudepotserver-webapp/src/main/resources/opensearch/opensearchdescription-body.ftl
+++ b/haikudepotserver-webapp/src/main/resources/opensearch/opensearchdescription-body.ftl
@@ -12,6 +12,6 @@
     <Image width="32" height="32" type="image/png">${baseUrl}/__img/haikudepot32.png</Image>
     <Image width="64" height="64" type="image/png">${baseUrl}/__img/haikudepot64.png</Image>
     <Image width="16" height="16" type="image/x-icon">${baseUrl}/__img/favicon.ico</Image>
-    <Url type="text/html" template="${baseUrl}/__pkgsearch/search?srchexpr={searchTerms}&amp;natlangcode=${naturalLanguageCode}"/>
-    <Language>${naturalLanguageCode}</Language>
+    <Url type="text/html" template="${baseUrl}/__pkgsearch/search?srchexpr={searchTerms}&amp;natlangcode=${naturalLanguageCoordinates}"/>
+    <Language>${naturalLanguageCoordinates}</Language>
 </OpenSearchDescription>


### PR DESCRIPTION
freemarker.core.InvalidReferenceException: The following has evaluated to null or missing: ==> naturalLanguageCode  [in template "opensearchdescription-body_en" at line 15, column 108]